### PR TITLE
Using auto_route_generator with analyzer ^v5.2.0 causes a bug.

### DIFF
--- a/lib/router.gr.dart
+++ b/lib/router.gr.dart
@@ -70,7 +70,7 @@ class TopRoute extends _i3.PageRouteInfo<void> {
 class SubRoute extends _i3.PageRouteInfo<SubRouteArgs> {
   SubRoute({
     _i4.Key? key,
-    required void Function() onPressed,
+    required dynamic onPressed,
   }) : super(
           SubRoute.name,
           path: '/sub-page',
@@ -91,7 +91,7 @@ class SubRouteArgs {
 
   final _i4.Key? key;
 
-  final void Function() onPressed;
+  final dynamic onPressed;
 
   @override
   String toString() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      sha256: "3444216bfd127af50bbe4862d8843ed44db946dd933554f0d7285e89f10e28ac"
       url: "https://pub.dev"
     source: hosted
-    version: "52.0.0"
+    version: "50.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: analyzer
-      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      sha256: "68796c31f510c8455a06fed75fc97d8e5ad04d324a830322ab3efc9feb6201c1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.2.0"
   args:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
+      sha256: "687cf90a3951affac1bd5f9ecb5e3e90b60487f3d9cdc359bb310f8876bb02a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: c2bea18c95cfa0276a366270afaa2850b09b4a76db95d546f3d003dcc7011298
+      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.7"
+    version: "1.2.6"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
 
   auto_route: 5.0.4
 
+  analyzer: 5.2.0
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
## Summary

Function type is ```dynamic```. It's a bug.

### Using analyzer v5.1.0

```dart
class SubRoute extends _i3.PageRouteInfo<SubRouteArgs> {
  SubRoute({
    _i4.Key? key,
    required void Function() onPressed,
  }) : super(...),
        );
  static const String name = 'SubRoute';
}
```

### Using analyzer ^v5.2.0

```dart
class SubRoute extends _i3.PageRouteInfo<SubRouteArgs> {
  SubRoute({
    _i4.Key? key,
    required dynamic onPressed,
  }) : super(...),
        );
  static const String name = 'SubRoute';
}
```